### PR TITLE
Add unit tests for domain models and parser modules

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,521 @@
+"""
+Unit tests for domain models: Paragraph, Chapter, Book, Character,
+CharacterAnalysis, TransformType, Transformation, TransformationChange.
+"""
+
+import pytest
+
+from src.models.book import Book, Chapter, Paragraph
+from src.models.character import Character, CharacterAnalysis, Gender
+from src.models.transformation import (
+    Transformation,
+    TransformationChange,
+    TransformationResult,
+    TransformType,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_paragraph(sentences=None):
+    return Paragraph(sentences=sentences or ["Hello world.", "Goodbye world."])
+
+
+def make_chapter(number=1, title="Chapter One", paragraphs=None):
+    return Chapter(
+        number=number,
+        title=title,
+        paragraphs=paragraphs or [make_paragraph()],
+    )
+
+
+def make_book(title="Test Book", author="Test Author", chapters=None):
+    return Book(
+        title=title,
+        author=author,
+        chapters=chapters or [make_chapter()],
+    )
+
+
+def make_character(name="Alice", gender=Gender.FEMALE, importance="main"):
+    return Character(
+        name=name,
+        gender=gender,
+        pronouns={"subject": "she", "object": "her", "possessive": "her"},
+        titles=["Ms."],
+        aliases=["Ally"],
+        importance=importance,
+        confidence=0.95,
+    )
+
+
+def make_analysis(characters=None):
+    return CharacterAnalysis(
+        book_id="abc123",
+        characters=characters or [make_character()],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Paragraph
+# ---------------------------------------------------------------------------
+
+
+class TestParagraph:
+    def test_get_text_joins_sentences(self):
+        p = Paragraph(sentences=["Hello.", "World."])
+        assert p.get_text() == "Hello. World."
+
+    def test_get_text_empty(self):
+        p = Paragraph(sentences=[])
+        assert p.get_text() == ""
+
+    def test_word_count(self):
+        p = Paragraph(sentences=["one two three", "four five"])
+        assert p.word_count() == 5
+
+    def test_word_count_empty(self):
+        assert Paragraph(sentences=[]).word_count() == 0
+
+    def test_to_dict_roundtrip(self):
+        p = Paragraph(sentences=["A sentence.", "Another one."])
+        restored = Paragraph.from_dict(p.to_dict())
+        assert restored.sentences == p.sentences
+
+    def test_from_dict_missing_key_defaults_to_empty(self):
+        p = Paragraph.from_dict({})
+        assert p.sentences == []
+
+
+# ---------------------------------------------------------------------------
+# Chapter
+# ---------------------------------------------------------------------------
+
+
+class TestChapter:
+    def test_get_text_joins_paragraphs_with_double_newline(self):
+        p1 = Paragraph(sentences=["First."])
+        p2 = Paragraph(sentences=["Second."])
+        ch = Chapter(number=1, title="T", paragraphs=[p1, p2])
+        assert ch.get_text() == "First.\n\nSecond."
+
+    def test_get_sentences_flattens_all(self):
+        p1 = Paragraph(sentences=["A.", "B."])
+        p2 = Paragraph(sentences=["C."])
+        ch = Chapter(number=1, title="T", paragraphs=[p1, p2])
+        assert ch.get_sentences() == ["A.", "B.", "C."]
+
+    def test_word_count_sums_paragraphs(self):
+        p1 = Paragraph(sentences=["one two"])
+        p2 = Paragraph(sentences=["three four five"])
+        ch = Chapter(number=1, title="T", paragraphs=[p1, p2])
+        assert ch.word_count() == 5
+
+    def test_to_dict_roundtrip(self):
+        ch = make_chapter()
+        restored = Chapter.from_dict(ch.to_dict())
+        assert restored.number == ch.number
+        assert restored.title == ch.title
+        assert len(restored.paragraphs) == len(ch.paragraphs)
+
+    def test_from_dict_defaults(self):
+        ch = Chapter.from_dict({"number": None, "title": None, "paragraphs": []})
+        assert ch.number is None
+        assert ch.paragraphs == []
+
+
+# ---------------------------------------------------------------------------
+# Book
+# ---------------------------------------------------------------------------
+
+
+class TestBook:
+    def test_word_count_sums_chapters(self):
+        ch1 = make_chapter(paragraphs=[Paragraph(["one two"])])
+        ch2 = make_chapter(number=2, paragraphs=[Paragraph(["three"])])
+        book = make_book(chapters=[ch1, ch2])
+        assert book.word_count() == 3
+
+    def test_chapter_count(self):
+        book = make_book(chapters=[make_chapter(), make_chapter(number=2)])
+        assert book.chapter_count() == 2
+
+    def test_get_chapter_by_number(self):
+        ch1 = make_chapter(number=1, title="First")
+        ch2 = make_chapter(number=2, title="Second")
+        book = make_book(chapters=[ch1, ch2])
+        assert book.get_chapter(2).title == "Second"
+
+    def test_get_chapter_missing_returns_none(self):
+        book = make_book()
+        assert book.get_chapter(99) is None
+
+    def test_get_text_includes_title_header(self):
+        ch = make_chapter(title="My Chapter", paragraphs=[Paragraph(["Body text."])])
+        book = make_book(chapters=[ch])
+        text = book.get_text()
+        assert "# My Chapter" in text
+        assert "Body text." in text
+
+    def test_hash_is_16_chars(self):
+        book = make_book()
+        assert len(book.hash()) == 16
+
+    def test_hash_is_deterministic(self):
+        book = make_book()
+        assert book.hash() == book.hash()
+
+    def test_hash_changes_with_content(self):
+        book1 = make_book(title="Book A")
+        book2 = make_book(title="Book B")
+        assert book1.hash() != book2.hash()
+
+    def test_to_dict_roundtrip(self):
+        book = make_book()
+        restored = Book.from_dict(book.to_dict())
+        assert restored.title == book.title
+        assert restored.author == book.author
+        assert restored.chapter_count() == book.chapter_count()
+
+    def test_validate_returns_no_errors_for_valid_book(self):
+        assert make_book().validate() == []
+
+    def test_validate_detects_no_chapters(self):
+        # Don't use make_book() — its default fills in chapters when passed []
+        book = Book(title="Test Book", author="Test Author", chapters=[])
+        errors = book.validate()
+        assert any("no chapters" in e.lower() for e in errors)
+
+    def test_validate_detects_empty_chapter(self):
+        empty_chapter = Chapter(number=1, title="Empty", paragraphs=[])
+        book = make_book(chapters=[empty_chapter])
+        errors = book.validate()
+        assert any("no paragraphs" in e.lower() for e in errors)
+
+    def test_validate_detects_empty_paragraph(self):
+        ch = Chapter(number=1, title="Ch", paragraphs=[Paragraph(sentences=[])])
+        book = make_book(chapters=[ch])
+        errors = book.validate()
+        assert any("no sentences" in e.lower() for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Gender
+# ---------------------------------------------------------------------------
+
+
+class TestGender:
+    def test_all_values_accessible(self):
+        assert Gender.MALE.value == "male"
+        assert Gender.FEMALE.value == "female"
+        assert Gender.NONBINARY.value == "non-binary"
+        assert Gender.UNKNOWN.value == "unknown"
+        assert Gender.NEUTRAL.value == "neutral"
+
+
+# ---------------------------------------------------------------------------
+# Character
+# ---------------------------------------------------------------------------
+
+
+class TestCharacter:
+    def test_get_all_names_includes_aliases(self):
+        c = make_character()
+        names = c.get_all_names()
+        assert "Alice" in names
+        assert "Ally" in names
+
+    def test_get_gendered_terms_female(self):
+        c = make_character(gender=Gender.FEMALE)
+        terms = c.get_gendered_terms()
+        assert terms["sibling"] == "sister"
+        assert terms["spouse"] == "wife"
+        assert terms["royalty"] == "queen"
+
+    def test_get_gendered_terms_male(self):
+        c = make_character(name="Bob", gender=Gender.MALE)
+        c.pronouns = {"subject": "he", "object": "him", "possessive": "his"}
+        terms = c.get_gendered_terms()
+        assert terms["sibling"] == "brother"
+        assert terms["spouse"] == "husband"
+        assert terms["royalty"] == "king"
+
+    def test_get_gendered_terms_nonbinary_has_no_sibling(self):
+        c = make_character(gender=Gender.NONBINARY)
+        terms = c.get_gendered_terms()
+        assert "sibling" not in terms
+
+    def test_to_dict_roundtrip(self):
+        c = make_character()
+        restored = Character.from_dict(c.to_dict())
+        assert restored.name == c.name
+        assert restored.gender == c.gender
+        assert restored.importance == c.importance
+        assert restored.confidence == c.confidence
+
+    def test_from_dict_string_pronouns_she_her(self):
+        c = Character.from_dict(
+            {
+                "name": "Alice",
+                "gender": "female",
+                "pronouns": "she/her/hers",
+            }
+        )
+        assert c.pronouns["subject"] == "she"
+        assert c.pronouns["object"] == "her"
+        assert c.pronouns["possessive"] == "hers"
+
+    def test_from_dict_string_pronouns_two_parts(self):
+        c = Character.from_dict(
+            {
+                "name": "Bob",
+                "gender": "male",
+                "pronouns": "he/him",
+            }
+        )
+        assert c.pronouns["subject"] == "he"
+        assert c.pronouns["object"] == "him"
+        # possessive falls back to object when only 2 parts
+        assert c.pronouns["possessive"] == "him"
+
+    def test_from_dict_none_pronouns(self):
+        c = Character.from_dict({"name": "X", "gender": "unknown", "pronouns": None})
+        assert c.pronouns == {}
+
+    def test_titles_primary_in_gendered_terms(self):
+        c = make_character()
+        c.titles = ["Lady", "Dame"]
+        terms = c.get_gendered_terms()
+        assert terms["title"] == "Lady"
+
+
+# ---------------------------------------------------------------------------
+# CharacterAnalysis
+# ---------------------------------------------------------------------------
+
+
+class TestCharacterAnalysis:
+    def test_get_character_by_name(self):
+        analysis = make_analysis()
+        assert analysis.get_character("Alice") is not None
+
+    def test_get_character_by_alias(self):
+        analysis = make_analysis()
+        assert analysis.get_character("Ally") is not None
+
+    def test_get_character_missing_returns_none(self):
+        analysis = make_analysis()
+        assert analysis.get_character("Nobody") is None
+
+    def test_get_main_characters(self):
+        main = make_character(importance="main")
+        supporting = make_character(name="Bob", importance="supporting")
+        analysis = make_analysis(characters=[main, supporting])
+        mains = analysis.get_main_characters()
+        assert len(mains) == 1
+        assert mains[0].name == "Alice"
+
+    def test_get_by_gender(self):
+        female = make_character(gender=Gender.FEMALE)
+        male = make_character(name="Bob", gender=Gender.MALE)
+        analysis = make_analysis(characters=[female, male])
+        females = analysis.get_by_gender(Gender.FEMALE)
+        assert len(females) == 1
+        assert females[0].name == "Alice"
+
+    def test_get_statistics(self):
+        chars = [
+            make_character(importance="main"),
+            make_character(name="Bob", gender=Gender.MALE, importance="supporting"),
+        ]
+        analysis = make_analysis(characters=chars)
+        stats = analysis.get_statistics()
+        assert stats["total"] == 2
+        assert stats["by_gender"]["female"] == 1
+        assert stats["by_gender"]["male"] == 1
+        assert "Alice" in stats["main_characters"]
+
+    def test_to_dict_roundtrip(self):
+        analysis = make_analysis()
+        d = analysis.to_dict()
+        restored = CharacterAnalysis.from_dict(d)
+        assert restored.book_id == analysis.book_id
+        assert len(restored.characters) == len(analysis.characters)
+
+    def test_create_context_string_contains_main_section(self):
+        analysis = make_analysis()
+        ctx = analysis.create_context_string()
+        assert "Main Characters" in ctx
+        assert "Alice" in ctx
+
+    def test_create_context_string_minor_shows_count(self):
+        chars = [make_character(importance="minor") for _ in range(3)]
+        analysis = make_analysis(characters=chars)
+        ctx = analysis.create_context_string()
+        assert "Minor Characters" in ctx
+        assert "3" in ctx
+
+
+# ---------------------------------------------------------------------------
+# TransformType
+# ---------------------------------------------------------------------------
+
+
+class TestTransformType:
+    def test_all_types_have_descriptions(self):
+        for tt in TransformType:
+            desc = tt.get_description()
+            assert isinstance(desc, str) and len(desc) > 0
+
+
+# ---------------------------------------------------------------------------
+# TransformationChange
+# ---------------------------------------------------------------------------
+
+
+class TestTransformationChange:
+    def test_to_dict_structure(self):
+        change = TransformationChange(
+            chapter_index=0,
+            paragraph_index=1,
+            sentence_index=2,
+            original="he",
+            transformed="she",
+            change_type="pronoun",
+            character_affected="Bob",
+        )
+        d = change.to_dict()
+        assert d["location"] == {"chapter": 0, "paragraph": 1, "sentence": 2}
+        assert d["original"] == "he"
+        assert d["transformed"] == "she"
+        assert d["type"] == "pronoun"
+        assert d["character"] == "Bob"
+
+
+# ---------------------------------------------------------------------------
+# Transformation
+# ---------------------------------------------------------------------------
+
+
+class TestTransformation:
+    def _make_transformation(self, changes=None, quality_score=None, n_chapters=1):
+        book = make_book()
+        chapters = [make_chapter(number=i + 1) for i in range(n_chapters)]
+        analysis = make_analysis()
+        return Transformation(
+            original_book=book,
+            transformed_chapters=chapters,
+            transform_type=TransformType.GENDER_SWAP,
+            characters_used=analysis,
+            changes=changes or [],
+            quality_score=quality_score,
+        )
+
+    def test_get_transformed_book_title_includes_type(self):
+        t = self._make_transformation()
+        transformed = t.get_transformed_book()
+        assert "gender_swap" in transformed.title
+
+    def test_get_transformed_book_preserves_author(self):
+        t = self._make_transformation()
+        assert t.get_transformed_book().author == "Test Author"
+
+    def test_get_changes_by_type(self):
+        changes = [
+            TransformationChange(0, 0, 0, "he", "she", "pronoun"),
+            TransformationChange(0, 0, 1, "him", "her", "pronoun"),
+            TransformationChange(0, 0, 2, "Mr.", "Ms.", "title"),
+        ]
+        t = self._make_transformation(changes=changes)
+        by_type = t.get_changes_by_type()
+        assert len(by_type["pronoun"]) == 2
+        assert len(by_type["title"]) == 1
+
+    def test_get_changes_by_character(self):
+        changes = [
+            TransformationChange(0, 0, 0, "he", "she", "pronoun", "Bob"),
+            TransformationChange(0, 0, 1, "him", "her", "pronoun", "Bob"),
+            TransformationChange(0, 0, 2, "she", "he", "pronoun", "Alice"),
+        ]
+        t = self._make_transformation(changes=changes)
+        by_char = t.get_changes_by_character()
+        assert len(by_char["Bob"]) == 2
+        assert len(by_char["Alice"]) == 1
+
+    def test_get_statistics(self):
+        changes = [TransformationChange(0, 0, 0, "he", "she", "pronoun")]
+        t = self._make_transformation(changes=changes, quality_score=85.0)
+        stats = t.get_statistics()
+        assert stats["total_changes"] == 1
+        assert stats["quality_score"] == 85.0
+        assert stats["chapters_transformed"] == 1
+
+    def test_validate_passes_for_valid(self):
+        changes = [TransformationChange(0, 0, 0, "he", "she", "pronoun")]
+        t = self._make_transformation(changes=changes)
+        assert t.validate() == []
+
+    def test_validate_detects_chapter_mismatch(self):
+        book = make_book(chapters=[make_chapter(1), make_chapter(2)])
+        analysis = make_analysis()
+        t = Transformation(
+            original_book=book,
+            transformed_chapters=[make_chapter(1)],  # only 1, should be 2
+            transform_type=TransformType.GENDER_SWAP,
+            characters_used=analysis,
+            changes=[TransformationChange(0, 0, 0, "he", "she", "pronoun")],
+        )
+        errors = t.validate()
+        assert any("mismatch" in e.lower() for e in errors)
+
+    def test_validate_detects_no_changes(self):
+        t = self._make_transformation(changes=[])
+        errors = t.validate()
+        assert any("no changes" in e.lower() for e in errors)
+
+    def test_validate_custom_type_allows_no_changes(self):
+        book = make_book()
+        analysis = make_analysis()
+        t = Transformation(
+            original_book=book,
+            transformed_chapters=[make_chapter()],
+            transform_type=TransformType.CUSTOM,
+            characters_used=analysis,
+            changes=[],
+        )
+        errors = t.validate()
+        assert not any("no changes" in e.lower() for e in errors)
+
+    def test_validate_detects_invalid_quality_score(self):
+        changes = [TransformationChange(0, 0, 0, "he", "she", "pronoun")]
+        t = self._make_transformation(changes=changes, quality_score=150.0)
+        errors = t.validate()
+        assert any("quality score" in e.lower() for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# TransformationResult
+# ---------------------------------------------------------------------------
+
+
+class TestTransformationResult:
+    def test_from_transformation_captures_stats(self):
+        book = make_book()
+        analysis = make_analysis()
+        changes = [TransformationChange(0, 0, 0, "he", "she", "pronoun")]
+        t = Transformation(
+            original_book=book,
+            transformed_chapters=[make_chapter()],
+            transform_type=TransformType.ALL_FEMALE,
+            characters_used=analysis,
+            changes=changes,
+            quality_score=90.0,
+        )
+        result = TransformationResult.from_transformation(t, processing_time=1.23)
+        assert result.total_changes == 1
+        assert result.transform_type == "all_female"
+        assert result.quality_score == 90.0
+        assert result.processing_time == 1.23
+        assert "chapters" in result.transformed_book

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,490 @@
+"""
+Unit tests for parser modules:
+- GutenbergParser (gutenberg.py)
+- FormatDetector (detector.py)
+- validate_and_clean_chapters / is_collection (chapter_validator.py)
+- BookConverter (book_converter.py)
+"""
+
+import pytest
+
+from src.parsers.book_converter import BookConverter
+from src.parsers.chapter_validator import is_collection, validate_and_clean_chapters
+from src.parsers.detector import BookFormat, FormatDetector
+from src.parsers.gutenberg import GutenbergMetadata, GutenbergParser, clean_gutenberg_text
+from src.parsers.parser import ParsedBook
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+GUTENBERG_HEADER = """\
+The Project Gutenberg EBook of Pride and Prejudice, by Jane Austen
+
+Title: Pride and Prejudice
+Author: Jane Austen
+Language: English
+Release Date: August 26, 2008 [EBook #1342]
+Produced by: Anonymous
+Character set encoding: UTF-8
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.
+
+*** START OF THIS PROJECT GUTENBERG EBOOK PRIDE AND PREJUDICE ***
+"""
+
+GUTENBERG_FOOTER = """
+*** END OF THIS PROJECT GUTENBERG EBOOK PRIDE AND PREJUDICE ***
+
+This eBook is for the use of anyone anywhere at no cost.
+"""
+
+
+def make_gutenberg_text(body: str) -> str:
+    return GUTENBERG_HEADER + body + GUTENBERG_FOOTER
+
+
+def make_chapter_dict(title="Chapter 1", paragraphs=None, para_count=5):
+    """Create a chapter dict with the given number of simple string paragraphs."""
+    if paragraphs is not None:
+        return {"title": title, "paragraphs": paragraphs}
+    return {
+        "title": title,
+        "paragraphs": [f"Paragraph {i + 1} text here." for i in range(para_count)],
+    }
+
+
+def make_parsed_book(title="Test", author="Author", chapters=None):
+    chapters = chapters or [
+        make_chapter_dict("Chapter 1", paragraphs=["First paragraph.", "Second paragraph."])
+    ]
+    return ParsedBook(
+        title=title,
+        author=author,
+        chapters=chapters,
+        metadata={},
+        format=BookFormat.STANDARD,
+        format_confidence=90.0,
+        hierarchy=None,
+        raw_text_length=100,
+        cleaned_text_length=80,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GutenbergParser
+# ---------------------------------------------------------------------------
+
+
+class TestGutenbergParser:
+    def setup_method(self):
+        self.parser = GutenbergParser()
+
+    # --- clean() strips headers/footers ---
+
+    def test_clean_removes_start_marker(self):
+        text = make_gutenberg_text("Chapter 1\n\nIt was a dark and stormy night.\n")
+        cleaned, _ = self.parser.clean(text)
+        assert "START OF THIS PROJECT GUTENBERG" not in cleaned
+
+    def test_clean_removes_end_marker(self):
+        text = make_gutenberg_text("Some content.\n")
+        cleaned, _ = self.parser.clean(text)
+        assert "END OF THIS PROJECT GUTENBERG" not in cleaned
+
+    def test_clean_preserves_body_content(self):
+        body = "Chapter 1\n\nIt was a dark and stormy night.\n"
+        text = make_gutenberg_text(body)
+        cleaned, _ = self.parser.clean(text)
+        assert "dark and stormy night" in cleaned
+
+    # --- metadata extraction ---
+
+    def test_clean_extracts_title(self):
+        text = make_gutenberg_text("Some body text.\n")
+        _, meta = self.parser.clean(text)
+        assert meta.title == "Pride and Prejudice"
+
+    def test_clean_extracts_author(self):
+        text = make_gutenberg_text("Some body text.\n")
+        _, meta = self.parser.clean(text)
+        assert meta.author == "Jane Austen"
+
+    def test_clean_extracts_language(self):
+        text = make_gutenberg_text("Some body text.\n")
+        _, meta = self.parser.clean(text)
+        assert meta.language == "English"
+
+    def test_clean_extracts_ebook_number(self):
+        text = make_gutenberg_text("Some body text.\n")
+        _, meta = self.parser.clean(text)
+        assert meta.ebook_number == "1342"
+
+    def test_clean_no_markers_returns_content(self):
+        # Text with no Gutenberg markers at all
+        plain = "Chapter 1\n\nThis is the story.\n\nThe end."
+        cleaned, meta = self.parser.clean(plain)
+        assert "This is the story." in cleaned
+
+    def test_metadata_defaults_to_none_when_absent(self):
+        plain = "Just some text with no metadata at all.\n" * 10
+        _, meta = self.parser.clean(plain)
+        assert isinstance(meta, GutenbergMetadata)
+
+    # --- _clean_lines: page numbers and illustration markers ---
+
+    def test_clean_lines_removes_page_numbers(self):
+        lines = ["Real content.", "42", "More content."]
+        result = self.parser._clean_lines(lines)
+        assert "42" not in result
+
+    def test_clean_lines_removes_illustration_markers(self):
+        lines = ["Paragraph text.", "[Illustration: A castle]", "More text."]
+        result = self.parser._clean_lines(lines)
+        assert not any("[Illustration" in line for line in result)
+
+    def test_clean_lines_collapses_excess_blank_lines(self):
+        lines = ["Text.", "", "", "", "", "More text."]
+        result = self.parser._clean_lines(lines)
+        blank_count = sum(1 for line in result if not line.strip())
+        assert blank_count <= 2
+
+    # --- _skip_toc ---
+
+    def test_skip_toc_removes_contents_section(self):
+        lines = [
+            "CONTENTS",
+            "Chapter I...1",
+            "Chapter II...5",
+            "Chapter III...10",
+            "",
+            "CHAPTER I",
+            "It was the best of times.",
+        ]
+        result = self.parser._skip_toc(lines)
+        # The actual chapter content should remain
+        assert any("best of times" in line for line in result)
+        # TOC entries should be gone or chapter content reached
+        chapter_idx = next((i for i, line in enumerate(result) if "CHAPTER I" in line), None)
+        assert chapter_idx is not None
+
+    # --- get_toc ---
+
+    def test_get_toc_extracts_toc(self):
+        text = "CONTENTS\nChapter I\nChapter II\n\n\n\nCHAPTER I\nStory begins."
+        toc = self.parser.get_toc(text)
+        assert toc is not None
+        assert "CONTENTS" in toc
+
+    def test_get_toc_returns_none_when_absent(self):
+        text = "CHAPTER I\nStory begins here."
+        assert self.parser.get_toc(text) is None
+
+    # --- convenience function ---
+
+    def test_clean_gutenberg_text_function(self):
+        text = make_gutenberg_text("Some content here.\n")
+        cleaned, meta = clean_gutenberg_text(text)
+        assert isinstance(cleaned, str)
+        assert isinstance(meta, GutenbergMetadata)
+
+
+# ---------------------------------------------------------------------------
+# FormatDetector
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDetector:
+    def setup_method(self):
+        self.detector = FormatDetector()
+
+    def _detect(self, text):
+        return self.detector.detect(text)
+
+    def test_standard_novel_detected(self):
+        text = "\n".join(
+            ["CHAPTER I", "Content here.", "CHAPTER II", "More content.", "CHAPTER III", "End."]
+            * 10
+        )
+        result = self._detect(text)
+        assert result.format == BookFormat.STANDARD
+
+    def test_play_format_detected(self):
+        text = "\n".join(
+            [
+                "ACT I",
+                "SCENE I",
+                "Enter HAMLET",
+                "HAMLET: To be or not to be.",
+                "[Exit HAMLET]",
+                "ACT II",
+                "SCENE I",
+                "Enter OPHELIA",
+                "[Exeunt]",
+            ]
+            * 5
+        )
+        result = self._detect(text)
+        assert result.format == BookFormat.PLAY
+
+    def test_multi_part_detected(self):
+        text = "\n".join(
+            [
+                "VOLUME I",
+                "CHAPTER I",
+                "Content here.",
+                "VOLUME II",
+                "CHAPTER I",
+                "More content.",
+            ]
+            * 5
+        )
+        result = self._detect(text)
+        assert result.format == BookFormat.MULTI_PART
+
+    def test_unknown_text_defaults_to_standard(self):
+        text = "Just some ordinary prose with no structural markers at all."
+        result = self._detect(text)
+        # Should default to STANDARD or UNKNOWN but not crash
+        assert result.format in (BookFormat.STANDARD, BookFormat.UNKNOWN)
+
+    def test_result_has_confidence_in_range(self):
+        lines = []
+        for i in range(10):
+            lines.extend([f"CHAPTER {i}", "Content."])
+        text = "\n".join(lines)
+        result = self._detect(text)
+        assert 0 <= result.confidence <= 100
+
+    def test_result_has_recommendations_list(self):
+        text = "CHAPTER I\nSome text."
+        result = self._detect(text)
+        assert isinstance(result.recommendations, list)
+
+    def test_result_has_evidence_dict(self):
+        text = "CHAPTER I\nSome text."
+        result = self._detect(text)
+        assert isinstance(result.evidence, dict)
+
+    def test_play_requires_both_acts_and_scenes(self):
+        # With only 2 acts and no scenes the penalised score (×0.3) stays below
+        # the 5-point detection threshold, so the format is NOT detected as PLAY.
+        text = "ACT I\nContent.\nACT II\nMore content."
+        result = self._detect(text)
+        assert result.format != BookFormat.PLAY
+
+    def test_toc_boosts_correct_format(self):
+        body = "\n".join(["CHAPTER I", "Content."] * 10)
+        toc = "CONTENTS\nChapter I\nChapter II\nChapter III\nChapter IV"
+        result = self.detector.detect(body, toc=toc)
+        assert result.format == BookFormat.STANDARD
+
+    def test_epistolary_detected(self):
+        text = "\n".join(
+            [
+                "Letter I",
+                "Dear Alice, I write to you.",
+                "Letter II",
+                "Dear Bob, I hope you are well.",
+                "Letter III",
+                "My dearest Charles, what news.",
+            ]
+            * 5
+        )
+        result = self._detect(text)
+        assert result.format == BookFormat.EPISTOLARY
+
+
+# ---------------------------------------------------------------------------
+# chapter_validator
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAndCleanChapters:
+    def test_empty_input_returns_empty(self):
+        assert validate_and_clean_chapters([]) == []
+
+    def test_valid_chapters_pass_through(self):
+        chapters = [make_chapter_dict(f"Chapter {i}", para_count=5) for i in range(3)]
+        result = validate_and_clean_chapters(chapters)
+        assert len(result) == 3
+
+    def test_chapters_are_renumbered_sequentially(self):
+        chapters = [make_chapter_dict(f"Chapter {i}", para_count=5) for i in range(3)]
+        result = validate_and_clean_chapters(chapters)
+        numbers = [ch["number"] for ch in result]
+        assert numbers == [1, 2, 3]
+
+    def test_tiny_chapters_merged_into_next(self):
+        tiny = make_chapter_dict("Tiny", para_count=1)  # below min_paragraphs=3
+        real = make_chapter_dict("Real Chapter", para_count=5)
+        result = validate_and_clean_chapters([tiny, real])
+        # real chapter should absorb the tiny one's content
+        # and result should still have at least 1 chapter
+        assert len(result) >= 1
+        assert result[-1]["paragraphs"]  # has content
+
+    def test_all_tiny_chapters_produce_single_fallback(self):
+        chapters = [make_chapter_dict(f"Ch {i}", para_count=1) for i in range(3)]
+        result = validate_and_clean_chapters(chapters)
+        # All content pooled into one chapter
+        assert len(result) == 1
+        assert len(result[0]["paragraphs"]) == 3  # one para from each tiny chapter
+
+    def test_custom_min_paragraphs(self):
+        # With min_paragraphs=1, even tiny chapters are valid
+        chapters = [make_chapter_dict(f"Ch {i}", para_count=1) for i in range(3)]
+        result = validate_and_clean_chapters(chapters, min_paragraphs=1)
+        assert len(result) == 3
+
+    def test_chapter_titles_preserved(self):
+        chapters = [make_chapter_dict("My Title", para_count=5)]
+        result = validate_and_clean_chapters(chapters)
+        assert result[0]["title"] == "My Title"
+
+    def test_empty_chapters_without_content_excluded(self):
+        chapters = [make_chapter_dict("Empty", para_count=0)]
+        result = validate_and_clean_chapters(chapters)
+        assert result == []
+
+
+class TestIsCollection:
+    def test_small_chapter_count_not_collection(self):
+        chapters = [make_chapter_dict() for _ in range(10)]
+        assert is_collection(chapters) is False
+
+    def test_many_acts_and_scenes_is_collection(self):
+        chapters = [{"title": f"Act {i} Scene {j}"} for i in range(10) for j in range(10)]
+        assert is_collection(chapters) is True
+
+    def test_many_regular_chapters_not_collection(self):
+        chapters = [{"title": f"Chapter {i}"} for i in range(150)]
+        assert is_collection(chapters) is False
+
+    def test_mixed_majority_acts_is_collection(self):
+        # 90 act/scene chapters out of 105 total = 85.7% > 50%; total > 100 threshold
+        act_chapters = [{"title": f"Act {i}"} for i in range(90)]
+        regular = [{"title": f"Chapter {i}"} for i in range(15)]
+        assert is_collection(act_chapters + regular) is True
+
+
+# ---------------------------------------------------------------------------
+# BookConverter
+# ---------------------------------------------------------------------------
+
+
+class TestBookConverter:
+    def setup_method(self):
+        self.converter = BookConverter()
+
+    # --- split_sentences ---
+
+    def test_split_basic_sentences(self):
+        text = "Hello world. Goodbye world."
+        sentences = self.converter.split_sentences(text)
+        assert len(sentences) == 2
+        assert sentences[0] == "Hello world."
+
+    def test_split_empty_string(self):
+        assert self.converter.split_sentences("") == []
+
+    def test_split_whitespace_only(self):
+        assert self.converter.split_sentences("   ") == []
+
+    def test_split_preserves_abbreviations(self):
+        text = "Mr. Smith went to Washington. He arrived safely."
+        sentences = self.converter.split_sentences(text)
+        # "Mr. Smith went to Washington." should be one sentence
+        assert any("Mr. Smith" in s for s in sentences)
+        assert len(sentences) == 2
+
+    def test_split_single_sentence_no_period(self):
+        text = "This is a sentence with no period"
+        sentences = self.converter.split_sentences(text)
+        assert sentences == ["This is a sentence with no period"]
+
+    def test_split_normalizes_whitespace(self):
+        text = "First  sentence.   Second sentence."
+        sentences = self.converter.split_sentences(text)
+        assert not any("  " in s for s in sentences)
+
+    # --- convert_paragraph ---
+
+    def test_convert_paragraph_returns_paragraph_object(self):
+        from src.models.book import Paragraph
+
+        p = self.converter.convert_paragraph("Hello. World.")
+        assert isinstance(p, Paragraph)
+        assert len(p.sentences) == 2
+
+    def test_convert_paragraph_empty_string(self):
+        p = self.converter.convert_paragraph("")
+        assert p.sentences == []
+
+    # --- convert_chapter ---
+
+    def test_convert_chapter_with_string_paragraphs(self):
+        chapter_dict = {
+            "number": 1,
+            "title": "The Beginning",
+            "paragraphs": ["First paragraph text.", "Second paragraph text."],
+        }
+        chapter = self.converter.convert_chapter(chapter_dict)
+        assert chapter.title == "The Beginning"
+        assert chapter.number == 1
+        assert len(chapter.paragraphs) == 2
+
+    def test_convert_chapter_with_dict_paragraphs(self):
+        chapter_dict = {
+            "number": 1,
+            "title": "Dict Chapter",
+            "paragraphs": [{"sentences": ["A sentence."]}],
+        }
+        chapter = self.converter.convert_chapter(chapter_dict)
+        assert len(chapter.paragraphs) == 1
+        assert chapter.paragraphs[0].sentences == ["A sentence."]
+
+    def test_convert_chapter_skips_empty_paragraphs(self):
+        chapter_dict = {
+            "number": 1,
+            "title": "Chapter",
+            "paragraphs": ["Real content.", ""],  # empty string produces no sentences
+        }
+        chapter = self.converter.convert_chapter(chapter_dict)
+        assert len(chapter.paragraphs) == 1
+
+    # --- convert ---
+
+    def test_convert_parsed_book_to_book(self):
+        from src.models.book import Book
+
+        parsed = make_parsed_book()
+        book = self.converter.convert(parsed)
+        assert isinstance(book, Book)
+        assert book.title == "Test"
+        assert book.author == "Author"
+
+    def test_convert_skips_empty_chapters(self):
+        parsed = make_parsed_book(
+            chapters=[
+                make_chapter_dict("Good Chapter", paragraphs=["Content here."]),
+                make_chapter_dict("Empty Chapter", paragraphs=[]),  # will be skipped
+            ]
+        )
+        book = self.converter.convert(parsed)
+        assert book.chapter_count() == 1
+
+    def test_convert_metadata_includes_format(self):
+        parsed = make_parsed_book()
+        book = self.converter.convert(parsed)
+        assert "format" in book.metadata
+
+    # --- convert_to_json ---
+
+    def test_convert_to_json_returns_dict(self):
+        parsed = make_parsed_book()
+        result = self.converter.convert_to_json(parsed)
+        assert isinstance(result, dict)
+        assert "chapters" in result
+        assert "metadata" in result


### PR DESCRIPTION
Adds 109 new tests across two files:

- tests/test_models.py: covers Paragraph, Chapter, Book (including
  validate(), hash(), serialisation roundtrips), Gender, Character
  (pronoun parsing, gendered-term lookup), CharacterAnalysis (querying,
  statistics, context string), TransformType, TransformationChange,
  Transformation (validate(), get_statistics(), get_transformed_book()),
  and TransformationResult.

- tests/test_parsers.py: covers GutenbergParser (header/footer
  stripping, metadata extraction, _clean_lines, _skip_toc, get_toc),
  FormatDetector (standard/play/multi-part/epistolary detection,
  confidence range, TOC boosting, acts-without-scenes penalty),
  validate_and_clean_chapters / is_collection, and BookConverter
  (sentence splitting with abbreviation protection, paragraph/chapter/
  book conversion).

https://claude.ai/code/session_01R3myLBKfCzyGi6YpfLZPHE