### PR TITLE
Harden provider retries, fix silent error swallow, add CI + provider tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main, master]
   pull_request:
   workflow_dispatch:
 
@@ -41,9 +41,6 @@ jobs:
   lint:
     name: Lint (advisory)
     runs-on: ubuntu-latest
-    # Advisory only: surfaces ruff findings without blocking the build while
-    # the repo's pre-existing lint debt is paid down incrementally.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -56,8 +53,13 @@ jobs:
       - name: Install ruff
         run: pip install ruff
 
+      # Advisory only: ruff findings are surfaced as annotations but do not
+      # fail the job, so the check stays green while the repo's pre-existing
+      # lint debt is paid down incrementally.
       - name: Ruff check
-        run: ruff check .
+        continue-on-error: true
+        run: ruff check --output-format=github .
 
       - name: Ruff format check
+        continue-on-error: true
         run: ruff format --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio
+
+      - name: Run tests
+        # Tests are the blocking gate: CI fails if any test fails.
+        # No API keys are configured, so the suite must run entirely on mocks.
+        run: python -m pytest -q
+
+  lint:
+    name: Lint (advisory)
+    runs-on: ubuntu-latest
+    # Advisory only: surfaces ruff findings without blocking the build while
+    # the repo's pre-existing lint debt is paid down incrementally.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [

--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -14,6 +14,11 @@ from src.providers.base_provider import BaseProviderPlugin
 class AnthropicProvider(BaseProviderPlugin):
     """Anthropic provider plugin implementation."""
 
+    # Maximum number of automatic retries on transient errors (529/429)
+    # before giving up and re-raising. Prevents unbounded recursion when
+    # the API is persistently overloaded or rate limited.
+    MAX_RETRIES = 3
+
     @property
     def provider_name(self) -> str:
         """Provider name."""
@@ -57,18 +62,17 @@ class AnthropicProvider(BaseProviderPlugin):
             self.client = AsyncAnthropic(api_key=self.api_key)
             self.logger.debug("Anthropic async client initialized")
         except ImportError as e:
-            raise ImportError(
-                "anthropic package not installed. Run: pip install anthropic"
-            ) from e
+            raise ImportError("anthropic package not installed. Run: pip install anthropic") from e
 
     async def _complete_impl(
-        self, messages: list[dict[str, str]], **kwargs
+        self, messages: list[dict[str, str]], _attempt: int = 0, **kwargs
     ) -> str:
         """
         Anthropic-specific completion implementation.
 
         Args:
             messages: List of message dicts
+            _attempt: Internal retry counter (do not set manually)
             **kwargs: Additional parameters
 
         Returns:
@@ -84,10 +88,7 @@ class AnthropicProvider(BaseProviderPlugin):
                 if msg["role"] == "system":
                     system_message = msg["content"]
                 else:
-                    claude_messages.append({
-                        "role": msg["role"],
-                        "content": msg["content"]
-                    })
+                    claude_messages.append({"role": msg["role"], "content": msg["content"]})
 
             # Prepare request parameters
             request_params = {
@@ -111,8 +112,7 @@ class AnthropicProvider(BaseProviderPlugin):
 
             # Make the API call with await and timeout (60 seconds)
             response = await asyncio.wait_for(
-                self.client.messages.create(**request_params),
-                timeout=60.0
+                self.client.messages.create(**request_params), timeout=60.0
             )
 
             # Extract the response text
@@ -127,30 +127,40 @@ class AnthropicProvider(BaseProviderPlugin):
 
             return content
 
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             self.logger.error("Anthropic API call timed out after 60 seconds")
-            raise TimeoutError("Anthropic API call timed out. The API may be slow or overloaded.")
+            raise TimeoutError(
+                "Anthropic API call timed out. The API may be slow or overloaded."
+            ) from e
         except Exception as e:
             error_message = str(e)
 
-            # Check for overloaded error (529) and retry
-            if "529" in error_message or "overloaded" in error_message.lower():
-                self.logger.warning("Anthropic API overloaded (529), waiting 30 seconds...")
-                await asyncio.sleep(30)
-                # Retry once
-                return await self._complete_impl(messages, **kwargs)
+            is_overloaded = "529" in error_message or "overloaded" in error_message.lower()
+            is_rate_limit = "429" in error_message or "rate" in error_message.lower()
 
-            # Check for rate limit (429)
-            elif "429" in error_message or "rate" in error_message.lower():
-                self.logger.warning(f"Anthropic rate limit hit: {e}")
-                await asyncio.sleep(60)  # Wait 60 seconds for rate limit
-                # Retry once
-                return await self._complete_impl(messages, **kwargs)
+            # Retry transient errors (overloaded/rate limit) with a bounded
+            # number of attempts to avoid unbounded recursion.
+            if is_overloaded or is_rate_limit:
+                if _attempt >= self.MAX_RETRIES:
+                    self.logger.error(
+                        f"Anthropic API still failing after {self.MAX_RETRIES} "
+                        f"retries, giving up: {e}"
+                    )
+                    raise
+
+                wait_time = 30 if is_overloaded else 60
+                reason = "overloaded (529)" if is_overloaded else "rate limit (429)"
+                self.logger.warning(
+                    f"Anthropic API {reason}, waiting {wait_time}s "
+                    f"(retry {_attempt + 1}/{self.MAX_RETRIES})..."
+                )
+                await asyncio.sleep(wait_time)
+                return await self._complete_impl(messages, _attempt=_attempt + 1, **kwargs)
 
             # Check for insufficient credits
-            elif "credit" in error_message.lower() or "billing" in error_message.lower():
+            if "credit" in error_message.lower() or "billing" in error_message.lower():
                 self.logger.error("Anthropic API credits/billing issue")
-                raise ValueError("Anthropic API billing issue. Please check your account.")
+                raise ValueError("Anthropic API billing issue. Please check your account.") from e
 
             # Log and re-raise other errors
             self.logger.error(f"Anthropic API error: {e}")
@@ -223,5 +233,5 @@ class AnthropicProvider(BaseProviderPlugin):
             "requests_limit": self.rate_limit,
             "tokens_remaining": "N/A",
             "reset_time": "Per minute",
-            "note": "Anthropic uses per-minute rate limits"
+            "note": "Anthropic uses per-minute rate limits",
         }

--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -14,6 +14,11 @@ from src.providers.base_provider import BaseProviderPlugin
 class OpenAIProvider(BaseProviderPlugin):
     """OpenAI provider plugin implementation."""
 
+    # Maximum number of automatic retries on transient errors (429)
+    # before giving up and re-raising. Prevents unbounded recursion when
+    # the API is persistently rate limited.
+    MAX_RETRIES = 3
+
     @property
     def provider_name(self) -> str:
         """Provider name."""
@@ -57,17 +62,18 @@ class OpenAIProvider(BaseProviderPlugin):
 
             self.client = AsyncOpenAI(api_key=self.api_key)
             self.logger.debug("OpenAI async client initialized")
-        except ImportError:
-            raise ImportError("openai package not installed. Run: pip install openai")
+        except ImportError as e:
+            raise ImportError("openai package not installed. Run: pip install openai") from e
 
     async def _complete_impl(
-        self, messages: list[dict[str, str]], **kwargs
+        self, messages: list[dict[str, str]], _attempt: int = 0, **kwargs
     ) -> str:
         """
         OpenAI-specific completion implementation.
 
         Args:
             messages: List of message dicts
+            _attempt: Internal retry counter (do not set manually)
             **kwargs: Additional parameters like temperature, max_tokens
 
         Returns:
@@ -91,8 +97,7 @@ class OpenAIProvider(BaseProviderPlugin):
 
             # Make the API call with await and timeout (60 seconds)
             response = await asyncio.wait_for(
-                self.client.chat.completions.create(**request_params),
-                timeout=60.0
+                self.client.chat.completions.create(**request_params), timeout=60.0
             )
 
             # Extract the response text
@@ -107,31 +112,42 @@ class OpenAIProvider(BaseProviderPlugin):
 
             return content
 
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             self.logger.error("OpenAI API call timed out after 60 seconds")
-            raise TimeoutError("OpenAI API call timed out. The API may be slow or overloaded.")
+            raise TimeoutError(
+                "OpenAI API call timed out. The API may be slow or overloaded."
+            ) from e
         except Exception as e:
             error_message = str(e)
 
-            # Handle rate limiting specifically
+            # Handle rate limiting specifically, with a bounded number of
+            # retries to avoid unbounded recursion under persistent limits.
             if "rate_limit" in error_message.lower() or "429" in error_message:
+                if _attempt >= self.MAX_RETRIES:
+                    self.logger.error(
+                        f"OpenAI API still rate limited after {self.MAX_RETRIES} "
+                        f"retries, giving up: {e}"
+                    )
+                    raise
+
                 self.logger.warning(f"Rate limit hit: {e}")
                 # Extract retry-after if available
                 wait_time = 60  # Default to 60 seconds
-                if hasattr(e, 'response') and e.response:
-                    retry_after = e.response.headers.get('retry-after')
+                if hasattr(e, "response") and e.response:
+                    retry_after = e.response.headers.get("retry-after")
                     if retry_after:
                         wait_time = int(retry_after)
 
-                self.logger.info(f"Waiting {wait_time} seconds before retry...")
+                self.logger.info(
+                    f"Waiting {wait_time}s before retry ({_attempt + 1}/{self.MAX_RETRIES})..."
+                )
                 await asyncio.sleep(wait_time)
-                # Retry once
-                return await self._complete_impl(messages, **kwargs)
+                return await self._complete_impl(messages, _attempt=_attempt + 1, **kwargs)
 
             # Handle other API errors
-            elif "insufficient_quota" in error_message.lower():
+            if "insufficient_quota" in error_message.lower():
                 self.logger.error("OpenAI API quota exceeded")
-                raise ValueError("OpenAI API quota exceeded. Please check your billing.")
+                raise ValueError("OpenAI API quota exceeded. Please check your billing.") from e
 
             # Log and re-raise other errors
             self.logger.error(f"OpenAI API error: {e}")
@@ -203,5 +219,5 @@ class OpenAIProvider(BaseProviderPlugin):
             "requests_limit": self.rate_limit,
             "tokens_remaining": "N/A",
             "reset_time": "Rolling window",
-            "note": "OpenAI uses rolling rate limits"
+            "note": "OpenAI uses rolling rate limits",
         }

--- a/src/services/text_export_service.py
+++ b/src/services/text_export_service.py
@@ -41,6 +41,7 @@ class TextExportService(BaseService):
 
         try:
             import unidecode
+
             self.unidecode = unidecode
             self.logger.info("Using unidecode for text normalization")
         except ImportError:
@@ -48,15 +49,18 @@ class TextExportService(BaseService):
 
         try:
             import ftfy
+
             self.ftfy = ftfy
             self.logger.info("Using ftfy for text fixing")
         except ImportError:
             self.logger.debug("ftfy not available")
 
         # Configuration options
-        extra = config.extra_config if hasattr(config, 'extra_config') else {}
+        extra = config.extra_config if hasattr(config, "extra_config") else {}
         self.use_unicode = extra.get("preserve_unicode", False)
-        self.normalize_method = extra.get("normalize_method", "unidecode")  # unidecode, ftfy, or basic
+        self.normalize_method = extra.get(
+            "normalize_method", "unidecode"
+        )  # unidecode, ftfy, or basic
 
         self.logger.info(f"Initialized {self.__class__.__name__}")
 
@@ -112,28 +116,28 @@ class TextExportService(BaseService):
         """
         # Smart replacements that preserve meaning
         replacements = {
-            '\u2019': "'",  # Right single quotation mark → apostrophe
-            '\u2018': "'",  # Left single quotation mark → apostrophe
-            '\u201C': '"',  # Left double quotation mark → regular quote
-            '\u201D': '"',  # Right double quotation mark → regular quote
-            '\u2014': "--",  # Em dash → double hyphen
-            '\u2013': "-",   # En dash → hyphen
-            '\u2026': "...", # Ellipsis → three dots
-            '\u00A0': " ",   # Non-breaking space → regular space
-            '\u2009': " ",   # Thin space → regular space
-            '\u2002': " ",   # En space → regular space
-            '\u2003': " ",   # Em space → regular space
-            '\u200B': "",    # Zero-width space → remove
-            '\u00AD': "",    # Soft hyphen → remove
-            '\uFEFF': "",    # Zero-width no-break space → remove
-            '\u00B4': "'",   # Acute accent → apostrophe
-            '\u0060': "'",   # Grave accent → apostrophe
-            '\u00A9': "(c)", # Copyright symbol
-            '\u00AE': "(R)", # Registered trademark
-            '\u2122': "(TM)", # Trademark symbol
-            '\u00BC': "1/4", # One quarter
-            '\u00BD': "1/2", # One half
-            '\u00BE': "3/4", # Three quarters
+            "\u2019": "'",  # Right single quotation mark → apostrophe
+            "\u2018": "'",  # Left single quotation mark → apostrophe
+            "\u201c": '"',  # Left double quotation mark → regular quote
+            "\u201d": '"',  # Right double quotation mark → regular quote
+            "\u2014": "--",  # Em dash → double hyphen
+            "\u2013": "-",  # En dash → hyphen
+            "\u2026": "...",  # Ellipsis → three dots
+            "\u00a0": " ",  # Non-breaking space → regular space
+            "\u2009": " ",  # Thin space → regular space
+            "\u2002": " ",  # En space → regular space
+            "\u2003": " ",  # Em space → regular space
+            "\u200b": "",  # Zero-width space → remove
+            "\u00ad": "",  # Soft hyphen → remove
+            "\ufeff": "",  # Zero-width no-break space → remove
+            "\u00b4": "'",  # Acute accent → apostrophe
+            "\u0060": "'",  # Grave accent → apostrophe
+            "\u00a9": "(c)",  # Copyright symbol
+            "\u00ae": "(R)",  # Registered trademark
+            "\u2122": "(TM)",  # Trademark symbol
+            "\u00bc": "1/4",  # One quarter
+            "\u00bd": "1/2",  # One half
+            "\u00be": "3/4",  # Three quarters
         }
 
         for old, new in replacements.items():
@@ -158,7 +162,7 @@ class TextExportService(BaseService):
 
         # Normalize using Python's built-in unicodedata
         # NFKD = compatibility decomposition
-        text = unicodedata.normalize('NFKD', text)
+        text = unicodedata.normalize("NFKD", text)
 
         # Keep only ASCII characters
         ascii_text = []
@@ -168,15 +172,16 @@ class TextExportService(BaseService):
             else:
                 # Try to get a name-based replacement
                 try:
-                    name = unicodedata.name(char, '')
-                    if 'LATIN' in name and 'LETTER' in name:
-                        # Skip combining marks
-                        if 'COMBINING' not in name:
-                            ascii_text.append('?')
-                except:
-                    pass
+                    name = unicodedata.name(char, "")
+                    # Latin letters (excluding combining marks) become "?"
+                    if "LATIN" in name and "LETTER" in name and "COMBINING" not in name:
+                        ascii_text.append("?")
+                except ValueError:
+                    # unicodedata.name raises ValueError for unnamed chars;
+                    # drop the character rather than failing the export.
+                    continue
 
-        return ''.join(ascii_text)
+        return "".join(ascii_text)
 
     async def process(self, book: Book) -> str:
         """
@@ -194,12 +199,12 @@ class TextExportService(BaseService):
         if book.title:
             title = self.simplify_text(book.title)
             lines.append(title)
-            lines.append('=' * len(title))
-            lines.append('')
+            lines.append("=" * len(title))
+            lines.append("")
 
         if book.author:
             lines.append(f"Author: {self.simplify_text(book.author)}")
-            lines.append('')
+            lines.append("")
 
         # Process chapters
         for chapter_num, chapter in enumerate(book.chapters, 1):
@@ -209,10 +214,10 @@ class TextExportService(BaseService):
             else:
                 chapter_title = f"Chapter {chapter_num}"
 
-            lines.append('')
+            lines.append("")
             lines.append(chapter_title)
-            lines.append('-' * len(chapter_title))
-            lines.append('')
+            lines.append("-" * len(chapter_title))
+            lines.append("")
 
             # Add paragraphs
             for paragraph in chapter.paragraphs:
@@ -221,9 +226,9 @@ class TextExportService(BaseService):
 
                 if cleaned_text.strip():
                     lines.append(cleaned_text)
-                    lines.append('')  # Empty line between paragraphs
+                    lines.append("")  # Empty line between paragraphs
 
-        return '\n'.join(lines)
+        return "\n".join(lines)
 
     def export_to_file(self, book: Book, output_path: str) -> str:
         """
@@ -246,7 +251,7 @@ class TextExportService(BaseService):
         output_path_obj = Path(output_path)
         output_path_obj.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(output_path_obj, 'w', encoding='utf-8') as f:
+        with open(output_path_obj, "w", encoding="utf-8") as f:
             f.write(text_content)
 
         self.logger.info(f"Exported text to: {output_path_obj}")
@@ -273,7 +278,7 @@ class TextExportService(BaseService):
 
         # Load JSON
         json_path_obj = Path(json_path)
-        with open(json_path_obj, encoding='utf-8') as f:
+        with open(json_path_obj, encoding="utf-8") as f:
             data = json.load(f)
 
         # Create Book object from JSON
@@ -281,6 +286,6 @@ class TextExportService(BaseService):
 
         # Determine output path
         if output_path is None:
-            output_path = str(json_path_obj.with_suffix('.txt'))
+            output_path = str(json_path_obj.with_suffix(".txt"))
 
         return self.export_to_file(book, output_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 Pytest configuration and fixtures for testing.
 """
+
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
@@ -17,8 +18,13 @@ class MockLLMProvider:
         self.supports_json = True
         self.calls = []
 
-    async def complete_async(self, messages, **kwargs):
-        """Mock LLM completion that returns gender-swapped text."""
+    async def complete(self, messages, **kwargs):
+        """Mock LLM completion that returns gender-swapped text.
+
+        Matches the real provider interface (``async def complete``) so that
+        services awaiting ``provider.complete(...)`` exercise the same code path
+        they would in production.
+        """
         # Track the call
         self.calls.append({"messages": messages, "kwargs": kwargs})
 
@@ -28,12 +34,14 @@ class MockLLMProvider:
         # Simple mock transformations based on content
         if "analyze characters" in user_msg.lower():
             # Return mock character analysis
-            return json.dumps({
-                "characters": [
-                    {"name": "James Wilson", "gender": "male", "importance": 10},
-                    {"name": "Sarah Chen", "gender": "female", "importance": 8}
-                ]
-            })
+            return json.dumps(
+                {
+                    "characters": [
+                        {"name": "James Wilson", "gender": "male", "importance": 10},
+                        {"name": "Sarah Chen", "gender": "female", "importance": 8},
+                    ]
+                }
+            )
         elif "gender" in user_msg.lower() and "swap" in user_msg.lower():
             # Return gender-swapped version
             response = user_msg.replace("Mr.", "Ms.")
@@ -48,11 +56,8 @@ class MockLLMProvider:
             # Default response
             return "Mocked response"
 
-    def complete(self, messages, **kwargs):
-        """Synchronous version for compatibility."""
-        import asyncio
-        loop = asyncio.new_event_loop()
-        return loop.run_until_complete(self.complete_async(messages, **kwargs))
+    # Backwards-compatible alias for any caller using the old name.
+    complete_async = complete
 
 
 @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 """
 Integration test - does the whole pipeline work?
 """
+
 import json
 from pathlib import Path
 
@@ -16,11 +17,10 @@ def test_pipeline_works_with_mock(app_with_mock, simple_story_path, tmp_path):
         file_path=simple_story_path,
         transform_type="gender_swap",
         output_path=output_file,
-        quality_control=False  # Skip QC for simplicity
     )
 
     # Basic checks that pipeline completed
-    assert result["success"] == True
+    assert result["success"] is True
     assert result["book_title"] is not None
     # Characters might be 0 with simple mock, that's OK
     assert "characters" in result
@@ -45,13 +45,10 @@ def test_parser_only_mode(app_with_mock, simple_story_path, tmp_path):
     """Test that we can just parse a book without transformation."""
 
     output_file = str(tmp_path / "parsed.json")
-    result = app_with_mock.parse_book_sync(
-        file_path=simple_story_path,
-        output_path=output_file
-    )
+    result = app_with_mock.parse_book_sync(file_path=simple_story_path, output_path=output_file)
 
     # Check parsing succeeded
-    assert result["success"] == True
+    assert result["success"] is True
     assert result["chapters"] > 0
     assert Path(output_file).exists()
 
@@ -71,12 +68,11 @@ def test_character_analysis_mode(app_with_mock, simple_story_path, tmp_path):
 
     output_file = str(tmp_path / "characters.json")
     result = app_with_mock.analyze_characters_sync(
-        file_path=simple_story_path,
-        output_path=output_file
+        file_path=simple_story_path, output_path=output_file
     )
 
     # Check analysis succeeded (might not find characters with basic mock)
-    assert result["success"] == True
+    assert result["success"] is True
     # Just check output was created, don't worry about character count
     assert Path(output_file).exists()
 
@@ -94,7 +90,6 @@ def test_pipeline_handles_bad_input(app_with_mock, tmp_path):
     result = app_with_mock.process_book_sync(
         file_path=str(bad_file),
         transform_type="gender_swap",
-        quality_control=False
     )
 
     # Should handle gracefully (might fail or succeed with empty output)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,185 @@
+"""
+Provider error-path tests.
+
+These exercise the retry/error handling branches in the OpenAI and Anthropic
+providers without making real API calls. The provider clients are replaced with
+mocks, and ``asyncio.sleep`` is patched out so the bounded-retry logic runs
+instantly instead of waiting the real 30/60 second backoffs.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.providers.anthropic import AnthropicProvider
+from src.providers.openai import OpenAIProvider
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Make every ``asyncio.sleep`` in the providers return immediately."""
+    fake_sleep = AsyncMock(return_value=None)
+    monkeypatch.setattr("src.providers.anthropic.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr("src.providers.openai.asyncio.sleep", fake_sleep)
+    return fake_sleep
+
+
+def _make_anthropic(create_side_effect=None, create_return=None):
+    """Build an AnthropicProvider with a mocked client."""
+    provider = AnthropicProvider()
+    provider.model = provider.default_model
+    provider._initialized = True
+    client = Mock()
+    client.messages = Mock()
+    client.messages.create = AsyncMock(side_effect=create_side_effect, return_value=create_return)
+    provider.client = client
+    return provider
+
+
+def _make_openai(create_side_effect=None, create_return=None):
+    """Build an OpenAIProvider with a mocked client."""
+    provider = OpenAIProvider()
+    provider.model = provider.default_model
+    provider._initialized = True
+    client = Mock()
+    client.chat = Mock()
+    client.chat.completions = Mock()
+    client.chat.completions.create = AsyncMock(
+        side_effect=create_side_effect, return_value=create_return
+    )
+    provider.client = client
+    return provider
+
+
+def _anthropic_response(text: str):
+    """Build a mock Anthropic SDK response object."""
+    block = Mock()
+    block.text = text
+    response = Mock()
+    response.content = [block]
+    return response
+
+
+def _openai_response(text: str):
+    """Build a mock OpenAI SDK response object."""
+    message = Mock()
+    message.content = text
+    choice = Mock()
+    choice.message = message
+    response = Mock()
+    response.choices = [choice]
+    return response
+
+
+# --------------------------------------------------------------------------- #
+# Anthropic
+# --------------------------------------------------------------------------- #
+
+
+async def test_anthropic_overload_retries_then_raises():
+    """A persistent 529 should retry MAX_RETRIES times, then re-raise (no infinite loop)."""
+    provider = _make_anthropic(create_side_effect=Exception("Error 529: overloaded"))
+
+    with pytest.raises(Exception, match="529"):
+        await provider._complete_impl([{"role": "user", "content": "hi"}])
+
+    # Initial attempt + MAX_RETRIES retries.
+    assert provider.client.messages.create.call_count == AnthropicProvider.MAX_RETRIES + 1
+
+
+async def test_anthropic_recovers_after_transient_overload():
+    """If the API recovers within the retry budget, the result is returned."""
+    provider = _make_anthropic(
+        create_side_effect=[
+            Exception("Error 529: overloaded"),
+            Exception("Error 529: overloaded"),
+            _anthropic_response("recovered"),
+        ]
+    )
+
+    result = await provider._complete_impl([{"role": "user", "content": "hi"}])
+
+    assert result == "recovered"
+    assert provider.client.messages.create.call_count == 3
+
+
+async def test_anthropic_rate_limit_retries_then_raises():
+    """A persistent 429 should also be bounded by MAX_RETRIES."""
+    provider = _make_anthropic(create_side_effect=Exception("Error 429: rate limit exceeded"))
+
+    with pytest.raises(Exception, match="429"):
+        await provider._complete_impl([{"role": "user", "content": "hi"}])
+
+    assert provider.client.messages.create.call_count == AnthropicProvider.MAX_RETRIES + 1
+
+
+async def test_anthropic_timeout_raises_timeouterror():
+    """A timeout is surfaced as a clear TimeoutError, not retried."""
+    provider = _make_anthropic(create_side_effect=asyncio.TimeoutError())
+
+    with pytest.raises(TimeoutError):
+        await provider._complete_impl([{"role": "user", "content": "hi"}])
+
+    # Timeouts are not part of the retry budget.
+    assert provider.client.messages.create.call_count == 1
+
+
+async def test_anthropic_billing_error_raises_valueerror():
+    """Billing/credit errors fail fast with an actionable ValueError."""
+    provider = _make_anthropic(create_side_effect=Exception("insufficient credit balance"))
+
+    with pytest.raises(ValueError, match="billing"):
+        await provider._complete_impl([{"role": "user", "content": "hi"}])
+
+    assert provider.client.messages.create.call_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# OpenAI
+# --------------------------------------------------------------------------- #
+
+
+async def test_openai_rate_limit_retries_then_raises():
+    """A persistent 429 should retry MAX_RETRIES times, then re-raise."""
+    provider = _make_openai(create_side_effect=Exception("Error 429: rate_limit exceeded"))
+
+    with pytest.raises(Exception, match="429"):
+        await provider._complete_impl([{"role": "user", "content": "hi"}])
+
+    assert provider.client.chat.completions.create.call_count == OpenAIProvider.MAX_RETRIES + 1
+
+
+async def test_openai_recovers_after_transient_rate_limit():
+    """If the API recovers within the retry budget, the result is returned."""
+    provider = _make_openai(
+        create_side_effect=[
+            Exception("Error 429: rate_limit"),
+            _openai_response("recovered"),
+        ]
+    )
+
+    result = await provider._complete_impl([{"role": "user", "content": "hi"}])
+
+    assert result == "recovered"
+    assert provider.client.chat.completions.create.call_count == 2
+
+
+async def test_openai_quota_error_raises_valueerror():
+    """Quota exhaustion fails fast with an actionable ValueError."""
+    provider = _make_openai(create_side_effect=Exception("insufficient_quota"))
+
+    with pytest.raises(ValueError, match="quota"):
+        await provider._complete_impl([{"role": "user", "content": "hi"}])
+
+    assert provider.client.chat.completions.create.call_count == 1
+
+
+async def test_openai_timeout_raises_timeouterror():
+    """A timeout is surfaced as a clear TimeoutError, not retried."""
+    provider = _make_openai(create_side_effect=asyncio.TimeoutError())
+
+    with pytest.raises(TimeoutError):
+        await provider._complete_impl([{"role": "user", "content": "hi"}])
+
+    assert provider.client.chat.completions.create.call_count == 1


### PR DESCRIPTION
## Summary

Production robustness improvements with **no feature/behavior changes**, plus a CI pipeline and provider error-path tests.

## Robustness fixes
- **Bounded provider retries** — `providers/anthropic.py` and `providers/openai.py` cap transient-error (529 / 429 / rate-limit) retries at `MAX_RETRIES = 3` instead of recursing unconditionally. This removes a potential infinite retry / hang when the API is persistently overloaded. Re-raises now attach exception context (`raise ... from e`).
- **No more silent error swallow** — replaced a bare `except: pass` in `services/text_export_service.py`'s ASCII normalization with a narrow `except ValueError`.

## Testing & CI
- **`tests/test_providers.py`** (new, 9 tests) — covers bounded-retry-then-raise, recovery-within-budget, timeout, and billing/quota error paths for both providers. `asyncio.sleep` is patched so the suite stays fast.
- **`tests/conftest.py`** — `MockLLMProvider.complete` is now `async`, matching the real provider interface. The previous sync wrapper raised inside the running event loop, so the transform path silently fell back to the term-map and never exercised the mock. Fixes the integration tests and cuts suite runtime from ~24s to <1s.
- **`tests/test_integration.py`** — drop the stale `quality_control` argument (removed from the app API); use `is True` truthiness checks.
- **`.github/workflows/ci.yml`** (new) — pytest is the **blocking** gate (runs fully on mocks, no API keys; matrix Python 3.11/3.12); ruff runs as an **advisory / non-blocking** job while the repo's pre-existing lint debt is paid down incrementally.
- **`pyproject.toml`** — add pytest config (`testpaths`, `asyncio_mode = "auto"`).

## Verification
- `pytest`: **19 passed, 1 skipped** (the skip is a Project Gutenberg book file not present in the checkout).
- All touched files pass `ruff check` and `ruff format --check`.

## Not included (out of scope — flagged for follow-up)
- The ~26 repo-wide ruff errors / 19 unformatted files (now surfaced by the advisory CI job).
- The dormant caching config and startup API-key validation (both more than "no feature impact").

https://claude.ai/code/session_011WknfK7frgzzf5xi9A3tua

---
_Generated by [Claude Code](https://claude.ai/code/session_011WknfK7frgzzf5xi9A3tua)_